### PR TITLE
Fixes `tests` endpoint to return the latests tests that were run within

### DIFF
--- a/src/psij/testing/service.py
+++ b/src/psij/testing/service.py
@@ -386,82 +386,32 @@ class TestingAggregatorApp(object):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def tests(self, sites_to_get, tests_to_match) -> object:
-
+        # should probably use json_in and pass all parameters as json
         import json
         sites_to_get = json.loads(sites_to_get)
-        tests_to_match = json.loads( tests_to_match)
+        tests_to_match = json.loads(tests_to_match)
 
-        # Example sites_to_get = ["mothra.hidden.uoregon.edu", "reptar.hidden.uoregon.edu", "saturn.hidden.uoregon.edu"]
+        now = datetime.datetime.now(datetime.timezone.utc)
+        time_limit = now - datetime.timedelta(hours=24)
+
+        tests = Test.objects(site_id__in=sites_to_get,
+                             branch__in=['main', 'master'],
+                             test_start_time__gt=time_limit,
+                             test_name__in=tests_to_match).order_by('-test_start_time')
+
         resp = {}
 
-        for site_id in sites_to_get:
-            resp[site_id] = self.getSite(site_id, tests_to_match)
+        for test in tests:
+            if test.site_id not in resp:
+                resp[test.site_id] = {}
+            # only store the more recent test
+            if test.test_name not in resp[test.site_id]:
+                resp[test.site_id][test.test_name] = test.to_mongo().to_dict()
+                for key in ['_id', "stdout", "stderr", "log"]:
+                    del resp[test.site_id][test.test_name][key]
 
         add_cors_headers()
         return resp
-
-
-    def getSite(self, site_id, tests_to_match):
-        #  Example site_id="mothra.hidden.uoregon.edu"
-        run_id = ""
-
-        try:
-            run_id = RunEnv.objects(site_id=site_id,
-                                    branch__in=['main','master']).order_by('-run_start_time')[0].run_id
-        except:
-            run_id = ""
-
-
-        resp = {}
-        resp['site_id'] = site_id
-        resp['run_id'] = run_id
-        branches = []
-        resp['branches'] = branches
-
-        runs = RunEnv.objects(site_id=site_id,run_id=run_id).order_by('+run_start_time')
-
-        for run in runs:
-
-            test_list = []
-            branch = run.to_mongo().to_dict()
-
-            branch['tests'] = test_list
-            branch['name'] = run.branch
-            branches.append(branch)
-
-            tests = Test.objects(site_id=site_id, run_id=run_id,
-                                 branch=run.branch,
-                                 test_name__in=tests_to_match).order_by('+test_start_time')
-
-            for test in tests:
-                test_dict = test.to_mongo().to_dict()
-                del test_dict['_id']
-                test_list.append(test_dict)
-
-
-        resBySiteIdAndTestName = {}
-        brs = resp['branches']
-
-        for testContainer in brs:
-
-            for oneTest in testContainer['tests']:
-
-                testName = oneTest['test_name']
-
-                foundMatch = 0
-
-                for test in tests_to_match:
-                    if testName == test:
-                        foundMatch = 1
-
-                branchMatch = oneTest['branch'] == 'master'
-
-                if foundMatch == 1:
-                    resBySiteIdAndTestName[testName] = oneTest['results']
-                    resBySiteIdAndTestName[testName]['branch'] = oneTest['branch']
-                    resBySiteIdAndTestName[testName]['test_start_time'] = oneTest['test_start_time']
-
-        return resBySiteIdAndTestName
 
 
 class Server:


### PR DESCRIPTION
24 hours in the past from now for a given site matching certain test names rather than looking in the latest run. The point of this is to return a "current" view of the test status, but using the latest run can lead to seemingly missing tests if a run is in progress but has not yet run the test in question.

The endpoint also returned results for test runs arbitrarily back in the past leading the possibility that sites that have been inactive for long periods of time would be shown as having current and passing tests.

Furthermore, the method returned results from some arbitrary branch. This commit fixes it to only return results from main/master.

The format of the returned results is also changes slightly. Previously, it looked like this:

  {
    "<site_id>": {
        "<test_name>": {
            <test_results_dict>,
            "branch": "<branch>",
            "test_start_time": "<test_start_time>"
        }
     }
  }

whereas now the <test_results_dict> is not mixed with the other keys, but returned separately:

  {
    "<site_id>": {
        "<test_name>": {
            "results": <test_results_dict>,
            "branch": "<branch>",
            "test_start_time": "<test_start_time>"
        }
     }
  }

This essentially keeps the test dict returned by the db unmodified under the "<test_name>" key.