### PR TITLE
Remove fixed backend URL so that relative links work properly. The

### DIFF
--- a/src/psij/web/instance/customization-psij.js
+++ b/src/psij/web/instance/customization-psij.js
@@ -3,7 +3,7 @@ CUSTOMIZATION = {
 };
 
 var CONF = {
-    backendURL: "https://psij.testing.exaworks.org/",
+    backendURL: "",
     STR: {
         "dashboardTitle": "Exascale dashboard testing service"
     },

--- a/src/psij/web/instance/customization-sdk.js
+++ b/src/psij/web/instance/customization-sdk.js
@@ -3,7 +3,7 @@ CUSTOMIZATION = {
 };
 
 var CONF = {
-    backendURL: "https://sdk.testing.exaworks.org/",
+    backendURL: "",
     STR: {
         "dashboardTitle": "Exascale dashboard testing service"
     },


### PR DESCRIPTION
frontend and backend are meant to be served from the same place, unless we are testing frontend features with existing backend data.